### PR TITLE
Small time optimisation for go

### DIFF
--- a/go3/src/concgo.go
+++ b/go3/src/concgo.go
@@ -23,7 +23,7 @@ import (
 type TimeMs = int
 
 func now_ms() TimeMs {
-	return int(time.Now().UnixNano() / 1e6)
+	return int(time.Now().UnixMilli())
 }
 
 func duration_ms(initial_moment TimeMs) TimeMs {


### PR DESCRIPTION
For go 1.17+ you can use `UnixMilli`